### PR TITLE
Update-release-tag

### DIFF
--- a/build/cd-pipeline.yaml
+++ b/build/cd-pipeline.yaml
@@ -33,3 +33,4 @@ stages:
       parameters:
         path: itwin-mobile-sdk-core-$(version).tgz
         artifactName: tarball
+        releaseTag: next


### PR DESCRIPTION
The default release tag is 'latest' and for the initial release of 3.0 we'll want to avoid publishing it as latest to not break anyone using the current packages.