### PR TITLE
Add support for min left/right safe area

### DIFF
--- a/src/mobile-sdk-core/MobileCore.scss
+++ b/src/mobile-sdk-core/MobileCore.scss
@@ -16,4 +16,6 @@
   --itm-safe-area-right: constant(safe-area-inset-right);
   --itm-safe-area-right: env(safe-area-inset-right);
   --itm-safe-area-bottom-over-keyboard: var(--itm-safe-area-bottom);
+  --itm-safe-area-min-left: var(--itm-safe-area-left);
+  --itm-safe-area-min-right: var(--itm-safe-area-right);
 }

--- a/src/mobile-sdk-core/MobileCore.ts
+++ b/src/mobile-sdk-core/MobileCore.ts
@@ -56,6 +56,8 @@ interface UpdateSafeAreaArgs {
   top: number;
   right: number;
   bottom: number;
+  minLeft?: number;
+  minRight?: number;
 }
 
 /** Class for top-level MobileCore functionality. */
@@ -360,12 +362,14 @@ export class MobileCore {
   private static _muiUpdateSafeAreas = async (args: UpdateSafeAreaArgs) => {
     const root = document.documentElement;
     for (const sideName in args) {
-      if (args.hasOwnProperty(sideName)) {
+      if (args.hasOwnProperty(sideName) && sideName !== "minLeft" && sideName !== "minRight") {
         const key = `--itm-safe-area-${sideName}`;
         const value = `${((args as any)[sideName]).toString()}px`;
         root.style.setProperty(key, value);
       }
     }
+    root.style.setProperty("--itm-safe-area-min-left", `${args.minLeft ?? args.left}px`);
+    root.style.setProperty("--itm-safe-area-min-right", `${args.minRight ?? args.right}px`);
   };
 }
 


### PR DESCRIPTION
On Android, the left and right safe areas are always set to be the same to keep UIs looking symmetric. This change lets an app make use of the actual left and right inset, if the app doesn't need the two sides to be symmetric.